### PR TITLE
docs: fix a little typo in Tabs data-attributes

### DIFF
--- a/apps/docs/src/routes/docs/components/tabs.mdx
+++ b/apps/docs/src/routes/docs/components/tabs.mdx
@@ -434,7 +434,7 @@ Individual tab can be disabled using the `isDisabled` prop on the tab itself.
 
 | Data attribute     | Description                                                                          |
 | :----------------- | :----------------------------------------------------------------------------------- |
-| data-selected      | Present when the trigger is seleceted.                                               |
+| data-selected      | Present when the trigger is selected.                                               |
 | data-disabled      | Present when the trigger is disabled.                                                |
 | data-hover         | Present when the trigger is hovered.                                                 |
 | data-focus         | Present when the trigger is focused.                                                 |


### PR DESCRIPTION
change 'seleceted' to 'selected'