### PR TITLE
feat: vanilla-extract utils

### DIFF
--- a/apps/vanilla-extract-playground/index.html
+++ b/apps/vanilla-extract-playground/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="theme-color" content="#000000" />
+    <link rel="shortcut icon" type="image/ico" href="/src/assets/favicon.ico" />
+    <title>Playground | Kobalte</title>
+  </head>
+  <body>
+    <noscript>You need to enable JavaScript to run this app.</noscript>
+    <div id="root"></div>
+
+    <script src="/src/index.tsx" type="module"></script>
+  </body>
+</html>

--- a/apps/vanilla-extract-playground/package.json
+++ b/apps/vanilla-extract-playground/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@kobalte/playground",
+  "name": "@kobalte/playground-vanilla-extract",
   "private": true,
   "description": "A SolidJS app playground for Kobalte.",
   "keywords": [

--- a/apps/vanilla-extract-playground/package.json
+++ b/apps/vanilla-extract-playground/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@kobalte/playground",
+  "private": true,
+  "description": "A SolidJS app playground for Kobalte.",
+  "keywords": [
+    "solid",
+    "solidjs",
+    "ui",
+    "library",
+    "design-system",
+    "components",
+    "headless",
+    "unstyled",
+    "aria"
+  ],
+  "homepage": "https://github.com/fabien-ml/kobalte/tree/main/apps/playground#readme",
+  "bugs": {
+    "url": "https://github.com/fabien-ml/kobalte/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/fabien-ml/kobalte.git"
+  },
+  "license": "MIT",
+  "author": "Fabien Marie-Louise <fabienml.dev@gmail.com>",
+  "scripts": {
+    "build": "vite build",
+    "dev": "vite",
+    "serve": "vite preview",
+    "start": "vite"
+  },
+  "dependencies": {
+    "@kobalte/core": "^0.3.0",
+    "@kobalte/vanilla-extract": "^0.1.0",
+    "@vanilla-extract/css": "^1.9.2",
+    "solid-js": "^1.6.1"
+  },
+  "devDependencies": {
+    "@vanilla-extract/vite-plugin": "^3.7.0",
+    "typescript": "^4.7.4",
+    "vite": "^3.0.3",
+    "vite-plugin-solid": "^2.3.0"
+  }
+}

--- a/apps/vanilla-extract-playground/src/App.tsx
+++ b/apps/vanilla-extract-playground/src/App.tsx
@@ -1,0 +1,15 @@
+import { Button, I18nProvider } from "@kobalte/core";
+import { button, container } from "./styles.css";
+
+export default function App() {
+  return (
+    <I18nProvider>
+      <div data-kb-theme="light" class={container}>
+        <Button.Root class={button}>Button</Button.Root>
+      </div>
+      <div data-kb-theme="dark" class={container}>
+        <Button.Root class={button}>Button</Button.Root>
+      </div>
+    </I18nProvider>
+  );
+}

--- a/apps/vanilla-extract-playground/src/index.css
+++ b/apps/vanilla-extract-playground/src/index.css
@@ -1,0 +1,7 @@
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu",
+    "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}

--- a/apps/vanilla-extract-playground/src/index.tsx
+++ b/apps/vanilla-extract-playground/src/index.tsx
@@ -1,0 +1,8 @@
+/* @refresh reload */
+import "./index.css";
+
+import { render } from "solid-js/web";
+
+import App from "./App";
+
+render(() => <App />, document.getElementById("root") as HTMLElement);

--- a/apps/vanilla-extract-playground/src/styles.css.ts
+++ b/apps/vanilla-extract-playground/src/styles.css.ts
@@ -1,0 +1,57 @@
+import { style } from "@vanilla-extract/css";
+import { componentStateStyles } from "@kobalte/vanilla-extract";
+
+export const container = style({
+  padding: "2rem",
+  selectors: {
+    "&[data-kb-theme=dark]": {
+      backgroundColor: "#1a1a1a",
+    },
+  },
+});
+
+export const button = style([
+  {
+    appearance: "none",
+    display: "inline-flex",
+    justifyContent: "center",
+    alignItems: "center",
+    border: "unset",
+    height: "40px",
+    width: "auto",
+    outline: "none",
+    borderRadius: "6px",
+    padding: "0 16px",
+    backgroundColor: "hsl(200 98% 39%)",
+    color: "white",
+    fontSize: "16px",
+    lineHeight: "0",
+    transition: "250ms background-color",
+  },
+  componentStateStyles({
+    hover: {
+      backgroundColor: "hsl(201 96% 32%)",
+    },
+    "focus-visible": {
+      outline: "2px solid hsl(200 98% 39%)",
+    },
+    active: {
+      backgroundColor: "hsl(201 90% 27%)",
+    },
+  }),
+  componentStateStyles(
+    {
+      hover: {
+        backgroundColor: "hsl(200 98% 39%)",
+
+        not: {
+          backgroundColor: "red",
+        },
+      },
+      active: {
+        backgroundColor: "hsl(199 89% 48%)",
+      },
+    },
+    { parentSelector: '[data-kb-theme="dark"]' }
+  ),
+]);

--- a/apps/vanilla-extract-playground/tsconfig.json
+++ b/apps/vanilla-extract-playground/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "types": ["vite/client"]
+  },
+  "include": ["src/**/*"]
+}

--- a/apps/vanilla-extract-playground/vite.config.ts
+++ b/apps/vanilla-extract-playground/vite.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "vite";
+import solidPlugin from "vite-plugin-solid";
+import { vanillaExtractPlugin } from "@vanilla-extract/vite-plugin";
+
+export default defineConfig({
+  plugins: [solidPlugin(), vanillaExtractPlugin()],
+  build: {
+    target: "esnext",
+    //minify: false,
+    sourcemap: true,
+  },
+});

--- a/packages/vanilla-extract/README.md
+++ b/packages/vanilla-extract/README.md
@@ -1,6 +1,6 @@
 # @kobalte/tailwindcss
 
-Vanilla Extract utils for styling Kobalte Elements easily.
+Vanilla Extract utils to style Kobalte Elements easily.
 
 ## Installation
 

--- a/packages/vanilla-extract/README.md
+++ b/packages/vanilla-extract/README.md
@@ -1,0 +1,72 @@
+# @kobalte/tailwindcss
+
+Vanilla Extract utils for styling Kobalte Elements easily.
+
+## Installation
+
+```bash
+npm install -D @kobalte/vanilla-extract
+# or
+yarn add -D @kobalte/vanilla-extract
+# or
+pnpm add -D @kobalte/vanilla-extract
+```
+
+## Usage
+
+### componentStateStyles
+
+In order to style kobalte elements with data-\* attributes you can use the `componentStateStyles` function in your `.css.ts` files.
+
+```ts
+// styles.css
+import { style } from "@vanilla-extract/css";
+import { componentStateStyles } from "@kobalte/vanilla-extract";
+
+const button = style([
+  {
+    background: "blue",
+    padding: "2px 6px",
+  },
+  componentStateStyles({
+    // { selectors: { &[data-disabled] {} }
+    disabled: {
+      opacity: 0.4,
+    },
+    // { selectors: { &[data-hover] {} }
+    hover: {
+      backgroundColor: "red",
+      // { selectors: { &:not([data-hover]) {} }
+      not: {
+        backgroundColor: "yellow",
+      },
+    },
+  }),
+  componentStateStyles(
+    {
+      // { selectors: { '[data-theme=dark] &[data-hover]'  {} }
+      hover: {
+        backgroundColor: "red",
+      },
+    },
+    { parentSelector: "[data-theme=dark]" }
+  ),
+]);
+```
+
+Then apply your styles to the component:
+
+```tsx
+import { Button } from "@kobalte/core";
+import { button } from "./styles.css";
+
+export const MyButton = () => <Button.Root class={button}>...</Button.Root>;
+```
+
+## Documentation
+
+For full documentation, visit [kobalte.dev](https://kobalte.dev/docs/overview/styling#using-the-tailwindcss-plugin).
+
+## Changelog
+
+All notable changes are described in the [CHANGELOG.md](./CHANGELOG.md) file.

--- a/packages/vanilla-extract/README.md
+++ b/packages/vanilla-extract/README.md
@@ -2,6 +2,8 @@
 
 Vanilla Extract utils for styling Kobalte Elements easily.
 
+> **Note** In order to use these utils you need to install @vanilla-extract/css and it's plugin to process the css (e.g. @vanilla-extract/vite-plugin). https://vanilla-extract.style
+
 ## Installation
 
 ```bash

--- a/packages/vanilla-extract/README.md
+++ b/packages/vanilla-extract/README.md
@@ -2,8 +2,6 @@
 
 Vanilla Extract utils for styling Kobalte Elements easily.
 
-> **Note** In order to use these utils you need to install @vanilla-extract/css and it's plugin to process the css (e.g. @vanilla-extract/vite-plugin). https://vanilla-extract.style
-
 ## Installation
 
 ```bash
@@ -14,11 +12,13 @@ yarn add -D @kobalte/vanilla-extract
 pnpm add -D @kobalte/vanilla-extract
 ```
 
+> **Note** In order to use these utils you need to configure Vanilla Extract in your project. https://vanilla-extract.style
+
 ## Usage
 
 ### componentStateStyles
 
-In order to style kobalte elements with data-\* attributes you can use the `componentStateStyles` function in your `.css.ts` files.
+Create vanilla-extract complaint styles for styling data-\* attributes of Kobalte Elements.
 
 ```ts
 // styles.css
@@ -31,26 +31,16 @@ const button = style([
     padding: "2px 6px",
   },
   componentStateStyles({
-    // { selectors: { &[data-disabled] {} }
-    disabled: {
-      opacity: 0.4,
-    },
-    // { selectors: { &[data-hover] {} }
+    disabled: { opacity: 0.4 },
     hover: {
       backgroundColor: "red",
-      // { selectors: { &:not([data-hover]) {} }
       not: {
         backgroundColor: "yellow",
       },
     },
   }),
   componentStateStyles(
-    {
-      // { selectors: { '[data-theme=dark] &[data-hover]'  {} }
-      hover: {
-        backgroundColor: "red",
-      },
-    },
+    { hover: { backgroundColor: "red" } },
     { parentSelector: "[data-theme=dark]" }
   ),
 ]);

--- a/packages/vanilla-extract/package.json
+++ b/packages/vanilla-extract/package.json
@@ -2,7 +2,7 @@
   "name": "@kobalte/vanilla-extract",
   "version": "0.1.0",
   "private": false,
-  "description": "Vanilla Extract utils for styling Kobalte Elements easily",
+  "description": "Vanilla Extract utils to style Kobalte Elements easily",
   "keywords": [
     "solid",
     "solidjs",

--- a/packages/vanilla-extract/package.json
+++ b/packages/vanilla-extract/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kobalte/vanilla-extract",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "private": false,
   "description": "A TailwindCSS plugin for styling Kobalte Elements with data-* attributes by using modifiers like ui-expanded:*",
   "keywords": [

--- a/packages/vanilla-extract/package.json
+++ b/packages/vanilla-extract/package.json
@@ -1,0 +1,55 @@
+{
+  "name": "@kobalte/vanilla-extract",
+  "version": "0.0.1",
+  "private": false,
+  "description": "A TailwindCSS plugin for styling Kobalte Elements with data-* attributes by using modifiers like ui-expanded:*",
+  "keywords": [
+    "solid",
+    "solidjs",
+    "ui",
+    "library",
+    "design-system",
+    "components"
+  ],
+  "homepage": "https://github.com/fabien-ml/kobalte/tree/main/packages/vanilla-extract#readme",
+  "bugs": {
+    "url": "https://github.com/fabien-ml/kobalte/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/fabien-ml/kobalte.git"
+  },
+  "license": "MIT",
+  "author": "Fabien Marie-Louise <fabienml.dev@gmail.com>",
+  "sideEffects": false,
+  "exports": {
+    ".": {
+      "import": "./dist/index.mjs",
+      "default": "./dist/index.mjs",
+      "require": "./dist/index.js",
+      "node": "./dist/index.js"
+    }
+  },
+  "main": "dist/index.js",
+  "module": "dist/index.mjs",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "clean": "rm -rf .turbo && rm -rf node_modules && rm -rf dist"
+  },
+  "dependencies": {
+    "@vanilla-extract/css": "^1.9.2"
+  },
+  "devDependencies": {
+    "tsup": "6.5.0"
+  },
+  "peerDependencies": {
+    "@vanilla-extract/css": "^1.9.2"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/vanilla-extract/package.json
+++ b/packages/vanilla-extract/package.json
@@ -2,7 +2,7 @@
   "name": "@kobalte/vanilla-extract",
   "version": "0.1.0",
   "private": false,
-  "description": "A TailwindCSS plugin for styling Kobalte Elements with data-* attributes by using modifiers like ui-expanded:*",
+  "description": "Vanilla Extract utils for styling Kobalte Elements easily",
   "keywords": [
     "solid",
     "solidjs",

--- a/packages/vanilla-extract/src/index.ts
+++ b/packages/vanilla-extract/src/index.ts
@@ -51,7 +51,7 @@ function makeSelectorByOptions(selector: string, options: SelectorOptions): stri
 
 type CompoonentStateStyleOptions = {
   /**
-   * Apply a parent selector to the given selector
+   * Apply the given parent selector to the `StyleRule` data-* attribute selector
    */
   parentSelector?: string;
 };

--- a/packages/vanilla-extract/src/index.ts
+++ b/packages/vanilla-extract/src/index.ts
@@ -14,18 +14,17 @@ function makeDataAttribute<TState extends string>(state: TState): DataAttribute<
 }
 
 function makeSelectorByOptions(selector: string, options: SelectorOptions): string {
-  let computedSelector = selector;
   if (options.not) {
-    computedSelector = `:not(${computedSelector})`;
+    selector = `:not(${selector})`;
   }
 
-  computedSelector = `&${computedSelector}`;
+  selector = `&${selector}`;
 
   if (options.parentSelector) {
-    computedSelector = `${options.parentSelector} ${computedSelector}`;
+    selector = `${options.parentSelector} ${selector}`;
   }
 
-  return computedSelector;
+  return selector;
 }
 
 type DataAttributeStates =
@@ -48,13 +47,19 @@ type DataAttributeStyles = {
   [key in DataAttributeStates]?: CSSProps & { not?: CSSProps };
 };
 
-type CompoonentStateStyleOptions = Pick<SelectorOptions, "parentSelector">;
+type CompoonentStateStyleOptions = {
+  /**
+   * Apply a parent selector to the given selector
+   */
+  parentSelector?: string;
+};
 
 export function componentStateStyles(
   styles: DataAttributeStyles,
   options?: CompoonentStateStyleOptions
 ): StyleRule {
   const styleRule = { selectors: {} } as { selectors: StyleRule["selectors"] };
+
   const selectorOptions: SelectorOptions = {
     parentSelector: options?.parentSelector ?? undefined,
   };

--- a/packages/vanilla-extract/src/index.ts
+++ b/packages/vanilla-extract/src/index.ts
@@ -1,33 +1,10 @@
 import type { StyleRule } from "@vanilla-extract/css";
 
-type DataAttribute<TState extends string> = `[data-${TState}]`;
+type DataAttribute<KobalteState extends string> = `[data-${KobalteState}]`;
 
 type CSSProps = Omit<StyleRule, "selectors" | "@media" | "@supports">;
 
-type SelectorOptions = {
-  parentSelector?: string;
-  not?: boolean;
-};
-
-function makeDataAttribute<TState extends string>(state: TState): DataAttribute<TState> {
-  return `[data-${state}]` as const;
-}
-
-function makeSelectorByOptions(selector: string, options: SelectorOptions): string {
-  if (options.not) {
-    selector = `:not(${selector})`;
-  }
-
-  selector = `&${selector}`;
-
-  if (options.parentSelector) {
-    selector = `${options.parentSelector} ${selector}`;
-  }
-
-  return selector;
-}
-
-type DataAttributeStates =
+export type DataAttributeState =
   | "valid"
   | "invalid"
   | "required"
@@ -43,9 +20,34 @@ type DataAttributeStates =
   | "focus-visible"
   | "active";
 
-type DataAttributeStyles = {
-  [key in DataAttributeStates]?: CSSProps & { not?: CSSProps };
+export type DataAttributeStyles = {
+  [key in DataAttributeState]?: CSSProps & { not?: CSSProps };
 };
+
+function makeDataAttribute<KobalteState extends string>(
+  state: KobalteState
+): DataAttribute<KobalteState> {
+  return `[data-${state}]` as const;
+}
+
+type SelectorOptions = {
+  parentSelector?: string;
+  not?: boolean;
+};
+
+function makeSelectorByOptions(selector: string, options: SelectorOptions): string {
+  if (options.not) {
+    selector = `:not(${selector})`;
+  }
+
+  selector = `&${selector}`;
+
+  if (options.parentSelector) {
+    selector = `${options.parentSelector} ${selector}`;
+  }
+
+  return selector;
+}
 
 type CompoonentStateStyleOptions = {
   /**
@@ -66,7 +68,7 @@ export function componentStateStyles(
 
   if (styleRule.selectors) {
     for (const property in styles) {
-      const { not, ...styleValues } = styles[property as DataAttributeStates] ?? {};
+      const { not, ...styleValues } = styles[property as DataAttributeState] ?? {};
       const dataAttrSelector = makeDataAttribute(property);
 
       if (not) {
@@ -85,5 +87,6 @@ export function componentStateStyles(
       styleRule.selectors[selector] = styleValues;
     }
   }
+
   return styleRule;
 }

--- a/packages/vanilla-extract/src/index.ts
+++ b/packages/vanilla-extract/src/index.ts
@@ -1,0 +1,44 @@
+import type { StyleRule } from "@vanilla-extract/css";
+
+type DataAttribute<TState extends string> = `[data-${TState}]`;
+
+type CSSProps = Omit<StyleRule, "selectors" | "@media" | "@supports">;
+
+function makeDataAttribute<TState extends string>(state: TState): DataAttribute<TState> {
+  return `[data-${state}]` as const;
+}
+
+type DataAttributeStates =
+  | "valid"
+  | "invalid"
+  | "required"
+  | "disabled"
+  | "readonly"
+  | "checked"
+  | "indeterminate"
+  | "selected"
+  | "pressed"
+  | "expanded"
+  | "hover"
+  | "focus"
+  | "focus-visible"
+  | "active";
+
+type DataAttributeStyles = {
+  [key in DataAttributeStates]?: CSSProps & { not?: CSSProps };
+};
+
+export function componentStateStyles(styles: DataAttributeStyles): StyleRule {
+  const styleRule = { selectors: {} } as { selectors: StyleRule["selectors"] };
+  if (styleRule.selectors) {
+    for (const property in styles) {
+      const { not, ...styleValues } = styles[property as DataAttributeStates] ?? {};
+      const selector = makeDataAttribute(property);
+      if (not) {
+        styleRule.selectors[`:not(${selector})&`] = not || {};
+      }
+      styleRule.selectors[`${selector}&`] = styleValues;
+    }
+  }
+  return styleRule;
+}

--- a/packages/vanilla-extract/tsconfig.json
+++ b/packages/vanilla-extract/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.json",
+  "exclude": ["node_modules", "./src", "./dist"]
+}

--- a/packages/vanilla-extract/tsup.config.ts
+++ b/packages/vanilla-extract/tsup.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  clean: true,
+  format: ["esm", "cjs"],
+  entryPoints: ["src/index.ts"],
+  dts: true,
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,7 +74,7 @@ importers:
       eslint-plugin-solid: 0.8.0_cglqs7bdoo3alqsht2x2xngibm
       husky: 8.0.1
       inquirer: 8.2.4
-      jest: 28.1.2_sgupjgtkb76w4hsvieap2xky7i
+      jest: 28.1.2_@types+node@18.7.18
       jest-environment-jsdom: 28.1.2
       lint-staged: 13.0.3
       prettier: 2.8.0
@@ -134,11 +134,11 @@ importers:
     devDependencies:
       '@kobalte/tailwindcss': link:../../packages/tailwindcss
       '@mdx-js/mdx': 2.1.3
-      '@mdx-js/rollup': 2.1.3_rollup@2.79.1
+      '@mdx-js/rollup': 2.1.3
       '@tailwindcss/typography': 0.5.9_tailwindcss@3.2.4
       acorn: 8.8.0
       autoprefixer: 10.4.13_postcss@8.4.19
-      babel-preset-solid: 1.6.1_@babel+core@7.20.12
+      babel-preset-solid: 1.6.1
       encoding: 0.1.13
       github-slugger: 1.4.0
       iconv-lite: 0.6.3
@@ -172,11 +172,11 @@ importers:
       vite-plugin-solid: ^2.3.0
     dependencies:
       '@kobalte/core': link:../../packages/core
-      solid-js: 1.6.9
+      solid-js: 1.6.1
     devDependencies:
-      typescript: 4.9.4
-      vite: 3.2.5
-      vite-plugin-solid: 2.5.0_solid-js@1.6.9+vite@3.2.5
+      typescript: 4.8.3
+      vite: 3.2.4
+      vite-plugin-solid: 2.5.0_solid-js@1.6.1+vite@3.2.4
 
   packages/core:
     specifiers:
@@ -201,7 +201,7 @@ importers:
       tsup: 6.5.0
     devDependencies:
       tailwindcss: 3.2.4
-      tsup: 6.5.0_postcss@8.4.21
+      tsup: 6.5.0
 
   packages/tests:
     specifiers:
@@ -219,10 +219,19 @@ importers:
       '@solid-primitives/refs': ^0.3.4
       '@solid-primitives/utils': ^4.0.0
     dependencies:
-      '@solid-primitives/event-listener': 2.2.4_solid-js@1.6.9
-      '@solid-primitives/media': 2.0.4_solid-js@1.6.9
-      '@solid-primitives/refs': 0.3.4_solid-js@1.6.9
-      '@solid-primitives/utils': 4.0.0_solid-js@1.6.9
+      '@solid-primitives/event-listener': 2.2.4
+      '@solid-primitives/media': 2.0.4
+      '@solid-primitives/refs': 0.3.4
+      '@solid-primitives/utils': 4.0.0
+
+  packages/vanilla-extract:
+    specifiers:
+      '@vanilla-extract/css': ^1.9.2
+      tsup: 6.5.0
+    dependencies:
+      '@vanilla-extract/css': 1.9.2
+    devDependencies:
+      tsup: 6.5.0
 
 packages:
 
@@ -1186,6 +1195,15 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.20.12
+      '@babel/helper-plugin-utils': 7.20.2
+    dev: true
+
+  /@babel/plugin-syntax-jsx/7.18.6:
+    resolution: {integrity: sha512-6mmljtAedFGTWu2p/8WIORGwy+61PLgOMPOdazc7YoJ9ZCWUyFy3A6CpPkRKLKD1ToAesxX8KGEViAiLo9N+7Q==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
@@ -2366,7 +2384,6 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       regenerator-runtime: 0.13.11
-    dev: true
 
   /@babel/template/7.20.7:
     resolution: {integrity: sha512-8SegXApWe6VoNw0r9JHpSteLKTpTiLZ4rMlGIm9JQ18KiCtyQiAMEazujAHrUS5flrcqYZa75ukev3P6QmUwUw==}
@@ -2798,6 +2815,10 @@ packages:
       '@jridgewell/trace-mapping': 0.3.9
     dev: true
 
+  /@emotion/hash/0.9.0:
+    resolution: {integrity: sha512-14FtKiHhy2QoPIzdTcvh//8OyBlknNs2nXRwIhG904opCby3l+9Xaf/wuPvICBF0rc1ZCNBd3nKe9cd2mecVkQ==}
+    dev: false
+
   /@esbuild/android-arm/0.15.18:
     resolution: {integrity: sha512-5GT+kcs2WVGjVs7+boataCkO5Fg0y4kCjzkB5bAip7H4jfnOS3dA6KPiww9W1OEKTKeAcUVhdZGvgI65OXmUnw==}
     engines: {node: '>=12'}
@@ -2923,7 +2944,7 @@ packages:
       slash: 3.0.0
     dev: true
 
-  /@jest/core/28.1.3_ts-node@10.9.1:
+  /@jest/core/28.1.3:
     resolution: {integrity: sha512-CIKBrlaKOzA7YG19BEqCw3SLIsEwjZkeJzf5bdooVnW4bH5cktqe3JX+G2YV1aK5vP8N9na1IGWFzYaTp6k6NA==}
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
     peerDependencies:
@@ -2944,7 +2965,7 @@ packages:
       exit: 0.1.2
       graceful-fs: 4.2.10
       jest-changed-files: 28.1.3
-      jest-config: 28.1.3_sgupjgtkb76w4hsvieap2xky7i
+      jest-config: 28.1.3_@types+node@18.7.18
       jest-haste-map: 28.1.3
       jest-message-util: 28.1.3
       jest-regex-util: 28.0.2
@@ -3255,7 +3276,7 @@ packages:
       estree-util-is-identifier-name: 2.0.1
       estree-util-to-js: 1.1.0
       estree-walker: 3.0.2
-      hast-util-to-estree: 2.2.0
+      hast-util-to-estree: 2.1.0
       markdown-extensions: 1.1.1
       periscopic: 3.0.4
       remark-mdx: 2.2.1
@@ -3270,14 +3291,13 @@ packages:
       - supports-color
     dev: true
 
-  /@mdx-js/rollup/2.1.3_rollup@2.79.1:
+  /@mdx-js/rollup/2.1.3:
     resolution: {integrity: sha512-KaX9GcZ63TDaLNH9UYYE94+naZQldV2IUzmMkDVOlPxDtTh8kcEn8l6/4W1P79wxZZbakSOFejTuaYmcstl5sA==}
     peerDependencies:
       rollup: '>=2'
     dependencies:
       '@mdx-js/mdx': 2.1.3
       '@rollup/pluginutils': 4.2.1
-      rollup: 2.79.1
       source-map: 0.7.4
       vfile: 5.3.6
     transitivePeerDependencies:
@@ -3460,61 +3480,54 @@ packages:
       '@sinonjs/commons': 1.8.6
     dev: true
 
-  /@solid-primitives/event-listener/2.2.4_solid-js@1.6.9:
+  /@solid-primitives/event-listener/2.2.4:
     resolution: {integrity: sha512-O/ppM0SpXWtNC7AHv1bQA9Dy6pj3NUM06MhSV9xwVv4N06PmlNYhGLDSPT1Esesm6b0fDgCXB5V+AgCSEzQd/w==}
     peerDependencies:
       solid-js: ^1.6.0
     dependencies:
-      '@solid-primitives/utils': 4.0.0_solid-js@1.6.9
-      solid-js: 1.6.9
+      '@solid-primitives/utils': 4.0.0
     dev: false
 
-  /@solid-primitives/immutable/0.1.4_solid-js@1.6.9:
+  /@solid-primitives/immutable/0.1.4:
     resolution: {integrity: sha512-9oLK8ihIjG5FZv74KoXXyKErxgGxGZsdevsIKB0ugTreBBmozHPcYTjoYFL/sHoqs2ZNMlmfNQ3kduvrvKG2RQ==}
     peerDependencies:
       solid-js: ^1.6.0
     dependencies:
-      '@solid-primitives/utils': 4.0.0_solid-js@1.6.9
-      solid-js: 1.6.9
+      '@solid-primitives/utils': 4.0.0
     dev: false
 
-  /@solid-primitives/media/2.0.4_solid-js@1.6.9:
+  /@solid-primitives/media/2.0.4:
     resolution: {integrity: sha512-MZkdUlV3qJQts4b7ZfAldbFGB1neH64rwHsnTmIeF2Zj8gWjYcYtJ36SwkRs3NjHQ53uQliZ+DtMXiCeapNw/g==}
     peerDependencies:
       solid-js: ^1.6.0
     dependencies:
-      '@solid-primitives/event-listener': 2.2.4_solid-js@1.6.9
-      '@solid-primitives/rootless': 1.2.1_solid-js@1.6.9
-      '@solid-primitives/utils': 4.0.0_solid-js@1.6.9
-      solid-js: 1.6.9
+      '@solid-primitives/event-listener': 2.2.4
+      '@solid-primitives/rootless': 1.2.1
+      '@solid-primitives/utils': 4.0.0
     dev: false
 
-  /@solid-primitives/refs/0.3.4_solid-js@1.6.9:
+  /@solid-primitives/refs/0.3.4:
     resolution: {integrity: sha512-XqX5PRCMnCOuLQqTsx3tRYs/oAyQsTXtmkB+tBlYoaqxLrJFBebPRVT/kFWN2Jxb6eZYAXDB5zZejS8nizsd8Q==}
     peerDependencies:
       solid-js: ^1.6.0
     dependencies:
-      '@solid-primitives/immutable': 0.1.4_solid-js@1.6.9
-      '@solid-primitives/rootless': 1.2.1_solid-js@1.6.9
-      '@solid-primitives/utils': 4.0.0_solid-js@1.6.9
-      solid-js: 1.6.9
+      '@solid-primitives/immutable': 0.1.4
+      '@solid-primitives/rootless': 1.2.1
+      '@solid-primitives/utils': 4.0.0
     dev: false
 
-  /@solid-primitives/rootless/1.2.1_solid-js@1.6.9:
+  /@solid-primitives/rootless/1.2.1:
     resolution: {integrity: sha512-8RpdyS1e58PQbDjgjpyCh+IGoX3QEs/2LauMfl94eXJ5d/o1y/c6P61z9XqQm+Bx1Otdgx4nbFCoF7HPqa0mwg==}
     peerDependencies:
       solid-js: ^1.6.0
     dependencies:
-      '@solid-primitives/utils': 4.0.0_solid-js@1.6.9
-      solid-js: 1.6.9
+      '@solid-primitives/utils': 4.0.0
     dev: false
 
-  /@solid-primitives/utils/4.0.0_solid-js@1.6.9:
+  /@solid-primitives/utils/4.0.0:
     resolution: {integrity: sha512-fGsJy8Z8YiwogpiezD7TWjI62UCb0JAHJWdoXWGrggrn4bfToZotKkabiB0IVFMkWVE1ZcrkvZT3bkmqGnK0ng==}
     peerDependencies:
       solid-js: ^1.6.0
-    dependencies:
-      solid-js: 1.6.9
     dev: false
 
   /@solidjs/meta/0.28.2_solid-js@1.6.1:
@@ -3523,6 +3536,7 @@ packages:
       solid-js: '>=1.4.0'
     dependencies:
       solid-js: 1.6.1
+    dev: false
 
   /@solidjs/router/0.5.0_solid-js@1.6.1:
     resolution: {integrity: sha512-rNR07l21tWWDVmCbaapggB89rEX7jlM2XChpTLqEGEnj46LzVZ8zgvjcF6NNKScByAlLpoQUkVIjB2KHpcMi+w==}
@@ -3530,6 +3544,7 @@ packages:
       solid-js: ^1.5.3
     dependencies:
       solid-js: 1.6.1
+    dev: false
 
   /@swc/helpers/0.4.14:
     resolution: {integrity: sha512-4C7nX/dvpzB7za4Ql9K81xK3HPxCpHMgwTZVyf+9JQ6VUbn9jjZVN7/Nkdz/Ugzs2CSjqnL/UPXroiVBVHUWUw==}
@@ -3812,7 +3827,7 @@ packages:
   /@types/resolve/1.17.1:
     resolution: {integrity: sha512-yy7HuzQhj0dhGpD8RLXSZWEkLsV9ibvxvi6EiJ3bkqLAO1RGo0WbkWQiwpRlSFymTJRz0d3k5LM3kkx8ArDbLw==}
     dependencies:
-      '@types/node': 18.7.18
+      '@types/node': 18.11.18
     dev: true
 
   /@types/semver/6.2.3:
@@ -4071,6 +4086,26 @@ packages:
       - supports-color
     dev: true
 
+  /@vanilla-extract/css/1.9.2:
+    resolution: {integrity: sha512-CE5+R89LOl9XG5dRwEIvVyl/YcS2GkqjdE/XnGJ+p7Fp6Exu08fifv7tY87XxFeCIRAbc9psM+h4lF+wC3Y0fg==}
+    dependencies:
+      '@emotion/hash': 0.9.0
+      '@vanilla-extract/private': 1.0.3
+      ahocorasick: 1.0.2
+      chalk: 4.1.2
+      css-what: 5.1.0
+      cssesc: 3.0.0
+      csstype: 3.1.1
+      deep-object-diff: 1.1.9
+      deepmerge: 4.2.2
+      media-query-parser: 2.0.2
+      outdent: 0.8.0
+    dev: false
+
+  /@vanilla-extract/private/1.0.3:
+    resolution: {integrity: sha512-17kVyLq3ePTKOkveHxXuIJZtGYs+cSoev7BlP+Lf4916qfDhk/HBjvlYDe8egrea7LNPHKwSZJK/bzZC+Q6AwQ==}
+    dev: false
+
   /@vinxi/rollup-plugin-visualizer/5.7.1_rollup@2.79.1:
     resolution: {integrity: sha512-gIwdH6B2rh7EoWgtL80yMW/0AM6riSXwNccM7rwMONG5CTVYzHYDQgnccrl40iWHrQLYZI0rvM66EQ1TRB8REA==}
     engines: {node: '>=14'}
@@ -4199,6 +4234,10 @@ packages:
       clean-stack: 2.2.0
       indent-string: 4.0.0
     dev: true
+
+  /ahocorasick/1.0.2:
+    resolution: {integrity: sha512-hCOfMzbFx5IDutmWLAt6MZwOUjIfSM9G9FyVxytmE4Rs/5YDPWQrD/+IR1w+FweD9H2oOZEnv36TmkjhNURBVA==}
+    dev: false
 
   /ajv/6.12.6:
     resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
@@ -4452,6 +4491,18 @@ packages:
       '@types/babel__traverse': 7.18.3
     dev: true
 
+  /babel-plugin-jsx-dom-expressions/0.35.13:
+    resolution: {integrity: sha512-UlbzUP/2kFxwaEs1VDrPjCr84/oGDQUohf+vbyD8u8Ct3tSpfQz+OGrj+GBqf0Ib1Rxz7dSH+1mZz+kuxzeCSA==}
+    peerDependencies:
+      '@babel/core': ^7.20.12
+    dependencies:
+      '@babel/helper-module-imports': 7.18.6
+      '@babel/plugin-syntax-jsx': 7.18.6
+      '@babel/types': 7.20.7
+      html-entities: 2.3.3
+      validate-html-nesting: 1.1.0
+    dev: true
+
   /babel-plugin-jsx-dom-expressions/0.35.13_@babel+core@7.19.1:
     resolution: {integrity: sha512-UlbzUP/2kFxwaEs1VDrPjCr84/oGDQUohf+vbyD8u8Ct3tSpfQz+OGrj+GBqf0Ib1Rxz7dSH+1mZz+kuxzeCSA==}
     peerDependencies:
@@ -4579,6 +4630,14 @@ packages:
       '@babel/core': 7.19.1
       babel-plugin-jest-hoist: 28.1.3
       babel-preset-current-node-syntax: 1.0.1_@babel+core@7.19.1
+    dev: true
+
+  /babel-preset-solid/1.6.1:
+    resolution: {integrity: sha512-Ji/cvYUE2BROsA3zOhaqKjuAEo6YAkmw8ZE11QsMtSEcWJ1rCFC829qWb5FLPl3UymVxh68+dpScPDtyyr/rdA==}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+    dependencies:
+      babel-plugin-jsx-dom-expressions: 0.35.13
     dev: true
 
   /babel-preset-solid/1.6.1_@babel+core@7.19.1:
@@ -4811,7 +4870,6 @@ packages:
     dependencies:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
-    dev: true
 
   /char-regex/1.0.2:
     resolution: {integrity: sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==}
@@ -5152,6 +5210,11 @@ packages:
       which: 2.0.2
     dev: true
 
+  /css-what/5.1.0:
+    resolution: {integrity: sha512-arSMRWIIFY0hV8pIxZMEfmMI47Wj3R/aWpZDDxWYCPEiOMv6tfOrnpDtgxBYPEQD4V0Y/958+1TdC3iWTFcUPw==}
+    engines: {node: '>= 6'}
+    dev: false
+
   /css.escape/1.5.1:
     resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
     dev: true
@@ -5160,7 +5223,6 @@ packages:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
     engines: {node: '>=4'}
     hasBin: true
-    dev: true
 
   /cssom/0.3.8:
     resolution: {integrity: sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==}
@@ -5324,10 +5386,13 @@ packages:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
     dev: true
 
+  /deep-object-diff/1.1.9:
+    resolution: {integrity: sha512-Rn+RuwkmkDwCi2/oXOFS9Gsr5lJZu/yTGpK7wAaAIE75CC+LCGEZHpY6VQJa/RoJcrmaA/docWJZvYohlNkWPA==}
+    dev: false
+
   /deepmerge/4.2.2:
     resolution: {integrity: sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==}
     engines: {node: '>=0.10.0'}
-    dev: true
 
   /defaults/1.0.4:
     resolution: {integrity: sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==}
@@ -7003,8 +7068,8 @@ packages:
       zwitch: 2.0.4
     dev: true
 
-  /hast-util-to-estree/2.2.0:
-    resolution: {integrity: sha512-QFMTJsd3+lr0TKiObJ6PWwpWqFjD+T28dVSazcPAslHjHGMXxs5xFvjLbUf6e6O3/dfHb9iourepMlSh5x7lIA==}
+  /hast-util-to-estree/2.1.0:
+    resolution: {integrity: sha512-Vwch1etMRmm89xGgz+voWXvVHba2iiMdGMKmaMfYt35rbVtFDq8JNwwAIvi8zHMkO6Gvqo9oTMwJTmzVRfXh4g==}
     dependencies:
       '@types/estree': 1.0.0
       '@types/estree-jsx': 1.0.0
@@ -7018,7 +7083,7 @@ packages:
       mdast-util-mdxjs-esm: 1.3.0
       property-information: 6.2.0
       space-separated-tokens: 2.0.2
-      style-to-object: 0.4.0
+      style-to-object: 0.3.0
       unist-util-position: 4.0.3
       zwitch: 2.0.4
     transitivePeerDependencies:
@@ -7650,7 +7715,7 @@ packages:
       - supports-color
     dev: true
 
-  /jest-cli/28.1.3_sgupjgtkb76w4hsvieap2xky7i:
+  /jest-cli/28.1.3_@types+node@18.7.18:
     resolution: {integrity: sha512-roY3kvrv57Azn1yPgdTebPAXvdR2xfezaKKYzVxZ6It/5NCxzJym6tUI5P1zkdWhfUYkxEI9uZWcQdaFLo8mJQ==}
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
     hasBin: true
@@ -7660,14 +7725,14 @@ packages:
       node-notifier:
         optional: true
     dependencies:
-      '@jest/core': 28.1.3_ts-node@10.9.1
+      '@jest/core': 28.1.3
       '@jest/test-result': 28.1.3
       '@jest/types': 28.1.3
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.10
       import-local: 3.1.0
-      jest-config: 28.1.3_sgupjgtkb76w4hsvieap2xky7i
+      jest-config: 28.1.3_@types+node@18.7.18
       jest-util: 28.1.3
       jest-validate: 28.1.3
       prompts: 2.4.2
@@ -7678,7 +7743,7 @@ packages:
       - ts-node
     dev: true
 
-  /jest-config/28.1.3_sgupjgtkb76w4hsvieap2xky7i:
+  /jest-config/28.1.3_@types+node@18.7.18:
     resolution: {integrity: sha512-MG3INjByJ0J4AsNBm7T3hsuxKQqFIiRo/AUqb1q9LRKI5UU6Aar9JHbr9Ivn1TVwfUD9KirRoM/T6u8XlcQPHQ==}
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
     peerDependencies:
@@ -7713,7 +7778,6 @@ packages:
       pretty-format: 28.1.3
       slash: 3.0.0
       strip-json-comments: 3.1.1
-      ts-node: 10.9.1_bidgzm5cq2du6gnjtweqqjrrn4
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -8107,7 +8171,7 @@ packages:
       supports-color: 8.1.1
     dev: true
 
-  /jest/28.1.2_sgupjgtkb76w4hsvieap2xky7i:
+  /jest/28.1.2_@types+node@18.7.18:
     resolution: {integrity: sha512-Tuf05DwLeCh2cfWCQbcz9UxldoDyiR1E9Igaei5khjonKncYdc6LDfynKCEWozK0oLE3GD+xKAo2u8x/0s6GOg==}
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
     hasBin: true
@@ -8117,10 +8181,10 @@ packages:
       node-notifier:
         optional: true
     dependencies:
-      '@jest/core': 28.1.3_ts-node@10.9.1
+      '@jest/core': 28.1.3
       '@jest/types': 28.1.1
       import-local: 3.1.0
-      jest-cli: 28.1.3_sgupjgtkb76w4hsvieap2xky7i
+      jest-cli: 28.1.3_@types+node@18.7.18
     transitivePeerDependencies:
       - '@types/node'
       - supports-color
@@ -8747,6 +8811,12 @@ packages:
   /mdast-util-to-string/3.1.0:
     resolution: {integrity: sha512-n4Vypz/DZgwo0iMHLQL49dJzlp7YtAJP+N07MZHpjPf/5XJuHUWstviF4Mn2jEiR/GNmtnRRqnwsXExk3igfFA==}
     dev: true
+
+  /media-query-parser/2.0.2:
+    resolution: {integrity: sha512-1N4qp+jE0pL5Xv4uEcwVUhIkwdUO3S/9gML90nqKA7v7FcOS5vUtatfzok9S9U1EJU8dHWlcv95WLnKmmxZI9w==}
+    dependencies:
+      '@babel/runtime': 7.20.7
+    dev: false
 
   /meow/6.1.1:
     resolution: {integrity: sha512-3YffViIt2QWgTy6Pale5QpopX/IvU3LPL03jOTqp6pGj3VjesdO/U8CuHMKpnQr4shCNCM5fd5XFFvIIl6JBHg==}
@@ -9449,6 +9519,10 @@ packages:
     resolution: {integrity: sha512-/jHxFIzoMXdqPzTaCpFzAAWhpkSjZPF4Vsn6jAfNpmbH/ymsmd7Qc6VE9BGn0L6YMj6uwpQLxCECpus4ukKS9Q==}
     dev: true
 
+  /outdent/0.8.0:
+    resolution: {integrity: sha512-KiOAIsdpUTcAXuykya5fnVVT+/5uS0Q1mrkRHcF89tpieSmY33O/tmc54CqwA+bfhbtEfZUNLHaPUiB9X3jt1A==}
+    dev: false
+
   /p-filter/2.1.0:
     resolution: {integrity: sha512-ZBxxZ5sL2HghephhpGAQdoskxplTwr7ICaehZwLIlfL6acuVgZPm8yBNuRAFBGEqtD/hmUeq9eqLg2ys9Xr/yw==}
     engines: {node: '>=8'}
@@ -9654,6 +9728,22 @@ packages:
     dependencies:
       camelcase-css: 2.0.1
       postcss: 8.4.21
+    dev: true
+
+  /postcss-load-config/3.1.4:
+    resolution: {integrity: sha512-6DiM4E7v4coTE4uzA8U//WhtPwyhiim3eyjEMFCnUpzbrkK9wJHgKDT2mR+HbtSrd/NubVaYTOpSpjUl8NQeRg==}
+    engines: {node: '>= 10'}
+    peerDependencies:
+      postcss: '>=8.0.9'
+      ts-node: '>=9.0.0'
+    peerDependenciesMeta:
+      postcss:
+        optional: true
+      ts-node:
+        optional: true
+    dependencies:
+      lilconfig: 2.0.6
+      yaml: 1.10.2
     dev: true
 
   /postcss-load-config/3.1.4_postcss@8.4.21:
@@ -9938,7 +10028,6 @@ packages:
 
   /regenerator-runtime/0.13.11:
     resolution: {integrity: sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==}
-    dev: true
 
   /regenerator-transform/0.15.1:
     resolution: {integrity: sha512-knzmNAcuyxV+gQCufkYcvOqX/qIIfHLv0u5x79kRxuGojfYVky1f15TzZEu2Avte8QGepvUNTnLskf8E6X6Vyg==}
@@ -10460,11 +10549,6 @@ packages:
     dependencies:
       csstype: 3.1.1
 
-  /solid-js/1.6.9:
-    resolution: {integrity: sha512-kV3fMmm+1C2J95c8eDOPKGfZHnuAkHUBLG4hX1Xu08bXeAIPqmxuz/QdH3B8SIdTp3EatBVIyA6RCes3hrGzpg==}
-    dependencies:
-      csstype: 3.1.1
-
   /solid-mdx/0.0.6_solid-js@1.6.1+vite@3.2.4:
     resolution: {integrity: sha512-SDr+iOqxvB7ktdjrwgKLCLkJK43J+TQjoYmesHxmZHXtn6W+a5NRqWgBcybsSP0noHa2co1plSjuPYU4bdtklQ==}
     peerDependencies:
@@ -10484,17 +10568,6 @@ packages:
       '@babel/helper-module-imports': 7.18.6
       '@babel/types': 7.20.7
       solid-js: 1.6.1
-    dev: true
-
-  /solid-refresh/0.4.2_solid-js@1.6.9:
-    resolution: {integrity: sha512-6g1HsgQkY0X0ZmsaydNgHwRaQIhH3bAbagZiYwWnGO7mqli50ehlwQUN18RZ2MH3fTIs9Y1bankZapVhMVuijg==}
-    peerDependencies:
-      solid-js: ^1.3
-    dependencies:
-      '@babel/generator': 7.20.7
-      '@babel/helper-module-imports': 7.18.6
-      '@babel/types': 7.20.7
-      solid-js: 1.6.9
     dev: true
 
   /solid-start-netlify/0.2.5_solid-start@0.2.5:
@@ -10838,12 +10911,6 @@ packages:
       inline-style-parser: 0.1.1
     dev: true
 
-  /style-to-object/0.4.0:
-    resolution: {integrity: sha512-dAjq2m87tPn/TcYTeqMhXJRhu96WYWcxMFQxs3Y9jfYpq2jG+38u4tj0Lst6DOiYXmDuNxVJ2b1Z2uPC6wTEeg==}
-    dependencies:
-      inline-style-parser: 0.1.1
-    dev: true
-
   /sucrase/3.29.0:
     resolution: {integrity: sha512-bZPAuGA5SdFHuzqIhTAqt9fvNEo9rESqXIG3oiKdF8K4UmkQxC4KlNL3lVyAErXp+mPvUqZ5l13qx6TrDIGf3A==}
     engines: {node: '>=8'}
@@ -11096,7 +11163,7 @@ packages:
       '@babel/core': 7.19.1
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
-      jest: 28.1.2_sgupjgtkb76w4hsvieap2xky7i
+      jest: 28.1.2_@types+node@18.7.18
       jest-util: 28.1.3
       json5: 2.2.3
       lodash.memoize: 4.1.2
@@ -11157,7 +11224,7 @@ packages:
   /tslib/2.4.1:
     resolution: {integrity: sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==}
 
-  /tsup/6.5.0_postcss@8.4.21:
+  /tsup/6.5.0:
     resolution: {integrity: sha512-36u82r7rYqRHFkD15R20Cd4ercPkbYmuvRkz3Q1LCm5BsiFNUgpo36zbjVhCOgvjyxNBWNKHsaD5Rl8SykfzNA==}
     engines: {node: '>=14'}
     hasBin: true
@@ -11181,8 +11248,7 @@ packages:
       execa: 5.1.1
       globby: 11.1.0
       joycon: 3.1.1
-      postcss: 8.4.21
-      postcss-load-config: 3.1.4_postcss@8.4.21
+      postcss-load-config: 3.1.4
       resolve-from: 5.0.0
       rollup: 3.10.0
       source-map: 0.8.0-beta.0
@@ -11409,12 +11475,6 @@ packages:
 
   /typescript/4.8.3:
     resolution: {integrity: sha512-goMHfm00nWPa8UvR/CPSvykqf6dVV8x/dp0c5mFTMTIu0u0FlGWRioyy7Nn0PGAdHxpJZnuO/ut+PpQ8UiHAig==}
-    engines: {node: '>=4.2.0'}
-    hasBin: true
-    dev: true
-
-  /typescript/4.9.4:
-    resolution: {integrity: sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==}
     engines: {node: '>=4.2.0'}
     hasBin: true
     dev: true
@@ -11735,24 +11795,6 @@ packages:
       - supports-color
     dev: true
 
-  /vite-plugin-solid/2.5.0_solid-js@1.6.9+vite@3.2.5:
-    resolution: {integrity: sha512-VneGd3RyFJvwaiffsqgymeMaofn0IzQLPwDzafTV2f1agoWeeJlk5VrI5WqT9BTtLe69vNNbCJWqLhHr9fOdDw==}
-    peerDependencies:
-      solid-js: ^1.3.17 || ^1.4.0 || ^1.5.0 || ^1.6.0
-      vite: ^3.0.0 || ^4.0.0
-    dependencies:
-      '@babel/core': 7.20.12
-      '@babel/preset-typescript': 7.18.6_@babel+core@7.20.12
-      babel-preset-solid: 1.6.9_@babel+core@7.20.12
-      merge-anything: 5.1.4
-      solid-js: 1.6.9
-      solid-refresh: 0.4.2_solid-js@1.6.9
-      vite: 3.2.5
-      vitefu: 0.2.4_vite@3.2.5
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
   /vite/3.2.2:
     resolution: {integrity: sha512-pLrhatFFOWO9kS19bQ658CnRYzv0WLbsPih6R+iFeEEhDOuYgYCX2rztUViMz/uy/V8cLCJvLFeiOK7RJEzHcw==}
     engines: {node: ^14.18.0 || >=16.0.0}
@@ -11816,39 +11858,6 @@ packages:
       fsevents: 2.3.2
     dev: true
 
-  /vite/3.2.5:
-    resolution: {integrity: sha512-4mVEpXpSOgrssFZAOmGIr85wPHKvaDAcXqxVxVRZhljkJOMZi1ibLibzjLHzJvcok8BMguLc7g1W6W/GqZbLdQ==}
-    engines: {node: ^14.18.0 || >=16.0.0}
-    hasBin: true
-    peerDependencies:
-      '@types/node': '>= 14'
-      less: '*'
-      sass: '*'
-      stylus: '*'
-      sugarss: '*'
-      terser: ^5.4.0
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-      less:
-        optional: true
-      sass:
-        optional: true
-      stylus:
-        optional: true
-      sugarss:
-        optional: true
-      terser:
-        optional: true
-    dependencies:
-      esbuild: 0.15.18
-      postcss: 8.4.21
-      resolve: 1.22.1
-      rollup: 2.79.1
-    optionalDependencies:
-      fsevents: 2.3.2
-    dev: true
-
   /vitefu/0.1.1_vite@3.2.2:
     resolution: {integrity: sha512-HClD14fjMJ+NQgXBqT3dC3RdO/+Chayil+cCPYZKY3kT+KcJomKzrdgzfCHJkIL2L0OAY+VPvrSW615iPtc7ag==}
     peerDependencies:
@@ -11869,17 +11878,6 @@ packages:
         optional: true
     dependencies:
       vite: 3.2.4
-    dev: true
-
-  /vitefu/0.2.4_vite@3.2.5:
-    resolution: {integrity: sha512-fanAXjSaf9xXtOOeno8wZXIhgia+CZury481LsDaV++lSvcU2R9Ch2bPh3PYFyoHW+w9LqAeYRISVQjUIew14g==}
-    peerDependencies:
-      vite: ^3.0.0 || ^4.0.0
-    peerDependenciesMeta:
-      vite:
-        optional: true
-    dependencies:
-      vite: 3.2.5
     dev: true
 
   /vscode-oniguruma/1.7.0:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -178,6 +178,27 @@ importers:
       vite: 3.2.4
       vite-plugin-solid: 2.5.0_solid-js@1.6.1+vite@3.2.4
 
+  apps/vanilla-extract-playground:
+    specifiers:
+      '@kobalte/core': ^0.3.0
+      '@kobalte/vanilla-extract': ^0.1.0
+      '@vanilla-extract/css': ^1.9.2
+      '@vanilla-extract/vite-plugin': ^3.7.0
+      solid-js: ^1.6.1
+      typescript: ^4.7.4
+      vite: ^3.0.3
+      vite-plugin-solid: ^2.3.0
+    dependencies:
+      '@kobalte/core': link:../../packages/core
+      '@kobalte/vanilla-extract': link:../../packages/vanilla-extract
+      '@vanilla-extract/css': 1.9.2
+      solid-js: 1.6.1
+    devDependencies:
+      '@vanilla-extract/vite-plugin': 3.7.0_vite@3.2.4
+      typescript: 4.8.3
+      vite: 3.2.4
+      vite-plugin-solid: 2.5.0_solid-js@1.6.1+vite@3.2.4
+
   packages/core:
     specifiers:
       '@floating-ui/dom': ^1.0.7
@@ -2817,7 +2838,6 @@ packages:
 
   /@emotion/hash/0.9.0:
     resolution: {integrity: sha512-14FtKiHhy2QoPIzdTcvh//8OyBlknNs2nXRwIhG904opCby3l+9Xaf/wuPvICBF0rc1ZCNBd3nKe9cd2mecVkQ==}
-    dev: false
 
   /@esbuild/android-arm/0.15.18:
     resolution: {integrity: sha512-5GT+kcs2WVGjVs7+boataCkO5Fg0y4kCjzkB5bAip7H4jfnOS3dA6KPiww9W1OEKTKeAcUVhdZGvgI65OXmUnw==}
@@ -4086,6 +4106,14 @@ packages:
       - supports-color
     dev: true
 
+  /@vanilla-extract/babel-plugin-debug-ids/1.0.0:
+    resolution: {integrity: sha512-Q2Nh/0FEAENfcphAv+fvcMoKfl3bhPWO/2x3MPviNAhsTsvuvYPuRtLjcXwoe4aJ8MxxI46JLY33j8NBEzpTIg==}
+    dependencies:
+      '@babel/core': 7.20.12
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@vanilla-extract/css/1.9.2:
     resolution: {integrity: sha512-CE5+R89LOl9XG5dRwEIvVyl/YcS2GkqjdE/XnGJ+p7Fp6Exu08fifv7tY87XxFeCIRAbc9psM+h4lF+wC3Y0fg==}
     dependencies:
@@ -4100,11 +4128,41 @@ packages:
       deepmerge: 4.2.2
       media-query-parser: 2.0.2
       outdent: 0.8.0
-    dev: false
+
+  /@vanilla-extract/integration/6.0.1:
+    resolution: {integrity: sha512-8D2JdBTH6UEao5Tm50m1qtY63JP4hDxiv/sNvgj2+ix/9M5RML9sa0diS80u0hW/r26+/ZsdzoA5YIbg6ghOMw==}
+    dependencies:
+      '@babel/core': 7.20.12
+      '@babel/plugin-syntax-typescript': 7.20.0_@babel+core@7.20.12
+      '@vanilla-extract/babel-plugin-debug-ids': 1.0.0
+      '@vanilla-extract/css': 1.9.2
+      esbuild: 0.11.23
+      eval: 0.1.6
+      find-up: 5.0.0
+      javascript-stringify: 2.1.0
+      lodash: 4.17.21
+      outdent: 0.8.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
 
   /@vanilla-extract/private/1.0.3:
     resolution: {integrity: sha512-17kVyLq3ePTKOkveHxXuIJZtGYs+cSoev7BlP+Lf4916qfDhk/HBjvlYDe8egrea7LNPHKwSZJK/bzZC+Q6AwQ==}
-    dev: false
+
+  /@vanilla-extract/vite-plugin/3.7.0_vite@3.2.4:
+    resolution: {integrity: sha512-Sq54d1f+Bww09e9Q5acFsNKjlSYMQ4GewJthdb3CVwUeGVzV10rJBChw6zufs7ndmJVCzQ4I2IcNMy2OiAlkmA==}
+    peerDependencies:
+      vite: ^2.2.3 || ^3.0.0
+    dependencies:
+      '@vanilla-extract/integration': 6.0.1
+      outdent: 0.8.0
+      postcss: 8.4.21
+      postcss-load-config: 3.1.4_postcss@8.4.21
+      vite: 3.2.4
+    transitivePeerDependencies:
+      - supports-color
+      - ts-node
+    dev: true
 
   /@vinxi/rollup-plugin-visualizer/5.7.1_rollup@2.79.1:
     resolution: {integrity: sha512-gIwdH6B2rh7EoWgtL80yMW/0AM6riSXwNccM7rwMONG5CTVYzHYDQgnccrl40iWHrQLYZI0rvM66EQ1TRB8REA==}
@@ -4237,7 +4295,6 @@ packages:
 
   /ahocorasick/1.0.2:
     resolution: {integrity: sha512-hCOfMzbFx5IDutmWLAt6MZwOUjIfSM9G9FyVxytmE4Rs/5YDPWQrD/+IR1w+FweD9H2oOZEnv36TmkjhNURBVA==}
-    dev: false
 
   /ajv/6.12.6:
     resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
@@ -5213,7 +5270,6 @@ packages:
   /css-what/5.1.0:
     resolution: {integrity: sha512-arSMRWIIFY0hV8pIxZMEfmMI47Wj3R/aWpZDDxWYCPEiOMv6tfOrnpDtgxBYPEQD4V0Y/958+1TdC3iWTFcUPw==}
     engines: {node: '>= 6'}
-    dev: false
 
   /css.escape/1.5.1:
     resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
@@ -5388,7 +5444,6 @@ packages:
 
   /deep-object-diff/1.1.9:
     resolution: {integrity: sha512-Rn+RuwkmkDwCi2/oXOFS9Gsr5lJZu/yTGpK7wAaAIE75CC+LCGEZHpY6VQJa/RoJcrmaA/docWJZvYohlNkWPA==}
-    dev: false
 
   /deepmerge/4.2.2:
     resolution: {integrity: sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==}
@@ -6029,6 +6084,12 @@ packages:
     dev: true
     optional: true
 
+  /esbuild/0.11.23:
+    resolution: {integrity: sha512-iaiZZ9vUF5wJV8ob1tl+5aJTrwDczlvGP0JoMmnpC2B0ppiMCu8n8gmy5ZTGl5bcG081XBVn+U+jP+mPFm5T5Q==}
+    hasBin: true
+    requiresBuild: true
+    dev: true
+
   /esbuild/0.14.54:
     resolution: {integrity: sha512-Cy9llcy8DvET5uznocPyqL3BFRrFXSVqbgpMJ9Wz8oVjZlh/zUSNbPRbov0VX7VxN2JH1Oa0uNxZ7eLRb62pJA==}
     engines: {node: '>=12'}
@@ -6460,6 +6521,13 @@ packages:
   /esutils/2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
+    dev: true
+
+  /eval/0.1.6:
+    resolution: {integrity: sha512-o0XUw+5OGkXw4pJZzQoXUk+H87DHuC+7ZE//oSrRGtatTmr12oTnLfg6QOq9DyTt0c/p4TwzgmkKrBzWTSizyQ==}
+    engines: {node: '>= 0.8'}
+    dependencies:
+      require-like: 0.1.2
     dev: true
 
   /execa/5.1.1:
@@ -7670,6 +7738,10 @@ packages:
       istanbul-lib-report: 3.0.0
     dev: true
 
+  /javascript-stringify/2.1.0:
+    resolution: {integrity: sha512-JVAfqNPTvNq3sB/VHQJAFxN/sPgKnsKrCwyRt15zwNCdrMMJDdcEOdubuy+DuJYYdm0ox1J4uzEuYKkN+9yhVg==}
+    dev: true
+
   /jest-axe/6.0.0:
     resolution: {integrity: sha512-gAh/2zoWii4Rbhe6IUIo5TTiseGJDCitFnDFwBNpIuaOciyQgVZue6jtd4W7oMoKHewKoRSuIol7t/MuGx+mqg==}
     engines: {node: '>= 10.0.0'}
@@ -8816,7 +8888,6 @@ packages:
     resolution: {integrity: sha512-1N4qp+jE0pL5Xv4uEcwVUhIkwdUO3S/9gML90nqKA7v7FcOS5vUtatfzok9S9U1EJU8dHWlcv95WLnKmmxZI9w==}
     dependencies:
       '@babel/runtime': 7.20.7
-    dev: false
 
   /meow/6.1.1:
     resolution: {integrity: sha512-3YffViIt2QWgTy6Pale5QpopX/IvU3LPL03jOTqp6pGj3VjesdO/U8CuHMKpnQr4shCNCM5fd5XFFvIIl6JBHg==}
@@ -9521,7 +9592,6 @@ packages:
 
   /outdent/0.8.0:
     resolution: {integrity: sha512-KiOAIsdpUTcAXuykya5fnVVT+/5uS0Q1mrkRHcF89tpieSmY33O/tmc54CqwA+bfhbtEfZUNLHaPUiB9X3jt1A==}
-    dev: false
 
   /p-filter/2.1.0:
     resolution: {integrity: sha512-ZBxxZ5sL2HghephhpGAQdoskxplTwr7ICaehZwLIlfL6acuVgZPm8yBNuRAFBGEqtD/hmUeq9eqLg2ys9Xr/yw==}
@@ -10176,6 +10246,10 @@ packages:
   /require-from-string/2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
+    dev: true
+
+  /require-like/0.1.2:
+    resolution: {integrity: sha512-oyrU88skkMtDdauHDuKVrgR+zuItqr6/c//FXzvmxRGMexSDc6hNvJInGW3LL46n+8b50RykrvwSUIIQH2LQ5A==}
     dev: true
 
   /require-main-filename/2.0.0:
@@ -11851,7 +11925,7 @@ packages:
         optional: true
     dependencies:
       esbuild: 0.15.18
-      postcss: 8.4.19
+      postcss: 8.4.21
       resolve: 1.22.1
       rollup: 2.79.1
     optionalDependencies:


### PR DESCRIPTION
Not sure about your intention to have a dedicated package for having utils for vanilla extract but i'm working on an internal project with kobalte and this could be useful to others too 👀 

This pr introduces a new package `@kobalte/vanilla-extract` that may exports some utils for vanilla-extract, just like the tailwind ones.

Currently I've added a `componentStateStyles` method that allows to compose the style for kobalte data-attributes selectors. This allows to write the selectors through a configuration object which has the vanilla-extract type constraints, instead of writing it from scratch (eg. &:not([data-hover]) or [data-theme=dark] &:[data-hover]))

Example
```ts
// Vanilla
const btn = style({
  selectors: {
    "&[data-hover]": {
      // styles
    },
    "&:not([data-active])": {
      // styles
    },
    ".parentClass &[data-active]": {
      // styles
    },
    ".parentClass &[data-hover]": {
      // styles
    }
  }
});


// With utils
const btn = style([
  componentStateStyles({
    hover: {
      // styles
    },
    active: {
      not: {
        // styles
      }
    }
  }),
  componentStateStyles(
    {
      hover: {},
      active: {
        // styles
      }
    },
    { parentSelector: ".parentClass" }
  )
]);
```


If something is not clear, or you think the API can be improved or missing, just tell me 😄 
