### PR TITLE
docs: wrap examples with return

### DIFF
--- a/apps/docs/src/routes/docs/core/components/dialog.mdx
+++ b/apps/docs/src/routes/docs/core/components/dialog.mdx
@@ -66,27 +66,29 @@ The dialog consists of:
     import "./style.css";
 
     function App() {
-      <Dialog.Root>
-        <Dialog.Trigger class="dialog__trigger">Open</Dialog.Trigger>
-        <Dialog.Portal>
-          <Dialog.Overlay class="dialog__overlay" />
-          <div class="dialog__positioner">
-            <Dialog.Content class="dialog__content">
-              <div class="dialog__header">
-                <Dialog.Title class="dialog__title">About Kobalte</Dialog.Title>
-                <Dialog.CloseButton class="dialog__close-button">
-                  <CrossIcon />
-                </Dialog.CloseButton>
-              </div>
-              <Dialog.Description class="dialog__description">
-                Kobalte is a UI toolkit for building accessible web apps and design systems with
-                SolidJS. It provides a set of low-level UI components and primitives which can be the
-                foundation for your design system implementation.
-              </Dialog.Description>
-            </Dialog.Content>
-          </div>
-        </Dialog.Portal>
-      </Dialog.Root>
+      return (
+        <Dialog.Root>
+          <Dialog.Trigger class="dialog__trigger">Open</Dialog.Trigger>
+          <Dialog.Portal>
+            <Dialog.Overlay class="dialog__overlay" />
+            <div class="dialog__positioner">
+              <Dialog.Content class="dialog__content">
+                <div class="dialog__header">
+                  <Dialog.Title class="dialog__title">About Kobalte</Dialog.Title>
+                  <Dialog.CloseButton class="dialog__close-button">
+                    <CrossIcon />
+                  </Dialog.CloseButton>
+                </div>
+                <Dialog.Description class="dialog__description">
+                  Kobalte is a UI toolkit for building accessible web apps and design systems with
+                  SolidJS. It provides a set of low-level UI components and primitives which can be the
+                  foundation for your design system implementation.
+                </Dialog.Description>
+              </Dialog.Content>
+            </div>
+          </Dialog.Portal>
+        </Dialog.Root>
+      );
     }
     ```
 

--- a/apps/docs/src/routes/docs/core/components/popover.mdx
+++ b/apps/docs/src/routes/docs/core/components/popover.mdx
@@ -68,23 +68,25 @@ The popover consists of:
     import "./style.css";
 
     function App() {
-      <Popover.Root>
-        <Popover.Trigger class="popover__trigger">Open</Popover.Trigger>
-        <Popover.Portal>
-          <Popover.Content class="popover__content">
-            <Popover.Arrow />
-            <div class="popover__header">
-              <Popover.Title class="popover__title">About Kobalte</Popover.Title>
-              <Popover.CloseButton class="popover__close-button">
-                <CrossIcon />
-              </Popover.CloseButton>
-            </div>
-            <Popover.Description class="popover__description">
-              A UI toolkit for building accessible web apps and design systems with SolidJS.
-            </Popover.Description>
-          </Popover.Content>
-        </Popover.Portal>
-      </Popover.Root>
+      return (
+        <Popover.Root>
+          <Popover.Trigger class="popover__trigger">Open</Popover.Trigger>
+          <Popover.Portal>
+            <Popover.Content class="popover__content">
+              <Popover.Arrow />
+              <div class="popover__header">
+                <Popover.Title class="popover__title">About Kobalte</Popover.Title>
+                <Popover.CloseButton class="popover__close-button">
+                  <CrossIcon />
+                </Popover.CloseButton>
+              </div>
+              <Popover.Description class="popover__description">
+                A UI toolkit for building accessible web apps and design systems with SolidJS.
+              </Popover.Description>
+            </Popover.Content>
+          </Popover.Portal>
+        </Popover.Root>
+      );
     }
     ```
 


### PR DESCRIPTION
Adds missing `return (...)` statement in the example code of https://kobalte.dev/docs/core/components/popover#example and https://kobalte.dev/docs/core/components/dialog#example